### PR TITLE
Also check for node that is down or unknown

### DIFF
--- a/check_kube_nodes.sh
+++ b/check_kube_nodes.sh
@@ -79,6 +79,7 @@ for NODE in ${NODES[*]}; do
 			"MemoryPressure-True") returnResult Critical;;
 			"DiskPressure-True") returnResult Critical;;
 			"Ready-False") returnResult Warning;;
+			"Ready-Unknown") returnResult Warning;;
 			# Note the API only checks these 4 conditions at present. Others can be added here.
 			*) returnResult OK;;
 		esac


### PR DESCRIPTION
Fixes #12 

Detects when a node is down or in an unknown state. Should include errors such as "Kubelet not posting status", where 

```
$ kubectl get nodes
NAME        STATUS       ROLES                      AGE    VERSION
docker01   Ready          controlplane,etcd,worker   421d   v1.17.4
docker02   NotReady   controlplane,etcd,worker   421d   v1.17.4
docker03   Ready          controlplane,etcd,worker   421d   v1.17.4

$ ./check_kube_nodes.sh -k kube_config_cluster.yml
Warning: docker02 has condition Ready - Unknown
$
```