### PR TITLE
Not killing proxy if using direct API access

### DIFF
--- a/check_kubernetes_api.sh
+++ b/check_kubernetes_api.sh
@@ -53,7 +53,10 @@ BSC_HEALTH=$(curl -sS $SSL $CREDENTIALS_FILE $TARGET/healthz/poststarthook/boots
 EXT_HEALTH=$(curl -sS $SSL $CREDENTIALS_FILE $TARGET/healthz/poststarthook/extensions/third-party-resources)
 BSR_HEALTH=$(curl -sS $SSL $CREDENTIALS_FILE $TARGET/healthz/poststarthook/rbac/bootstrap-roles)
 
-kill -15 $PROXY_PID
+if [ -n "$PROXY_PID" ]
+then
+    kill -15 $PROXY_PID
+fi
 
 case "$HEALTH $BSC_HEALTH $BSR_HEALTH" in 
 	"ok ok ok") echo "OK - Kubernetes API status is OK" && exit 0;;


### PR DESCRIPTION
Hello,

The check_kubernetes_api.sh displays a "kill" error message when running it with direct access to Kube API, since it tries to kill a non-running proxy.

The exact error :
`kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]`

Here is a small fix for that.

Regards,