### PR TITLE
In pod deployments we are interested only in current condition

### DIFF
--- a/check_kube_deployments.sh
+++ b/check_kube_deployments.sh
@@ -95,9 +95,9 @@ for NAMESPACE in ${NAMESPACES[*]}; do
 	DEPLOYMENTS=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[].metadata.name')
 	# Itterate through each deployment
 	for DEPLOYMENT in ${DEPLOYMENTS[*]}; do
-		TYPE=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions[].type' )
-		STATUS=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions[].status' )
-		REASON=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions[].message' )
+		TYPE=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.lastTransitionTime) | .status.conditions[-1].type' )
+		STATUS=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.lastTransitionTime) | .status.conditions[-1].status' )
+		REASON=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.lastTransitionTime) | .status.conditions[-1].message' )
 		# uncomment the following line to test a failure:
 		# if [[ "$DEPLOYMENT" == "kubernetes-dashboard" ]]; then TYPE="Available"; STATUS="False"; fi
 		case "${TYPE}-${STATUS}" in


### PR DESCRIPTION
Before this change I got "unknown" status for some pods:

```
# ./check_kube_deployments.sh -n kube-system
Unknown: coredns has condition Progressing
Available: True
True - ReplicaSet "coredns-74ff55c5b" has successfully progressed.
Deployment has minimum availability.

# echo $?
3
```

This is because there are two "historical" conditions - one emitted at "13:22:06" saying "Progressing" and then a newer one at "17:57:55" saying "Available". However, "check_kube_deployments.sh" took the older one:

```
# kubectl get deployment coredns -n kube-system -o yaml

[...]
status:
  availableReplicas: 2
  conditions:
  - lastTransitionTime: "2021-02-25T13:22:06Z"
    lastUpdateTime: "2021-02-25T13:25:05Z"
    message: ReplicaSet "coredns-74ff55c5b" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  - lastTransitionTime: "2021-02-25T17:57:55Z"
    lastUpdateTime: "2021-02-25T17:57:55Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  observedGeneration: 1
  readyReplicas: 2
  replicas: 2
  updatedReplicas: 2
```

After this change, the conditions are sorted from oldest to newest and code takes only the last (newest) status:

```
# ./check_kube_deployments.sh -n kube-system
OK - Kubernetes deployments are all OK
OK: coredns has condition Available: True - Deployment has minimum availability.

# echo $?
0
```