### PR TITLE
check_kube_deployments: Address managing different sorting of conditions

### DIFF
--- a/check_kube_deployments.sh
+++ b/check_kube_deployments.sh
@@ -96,9 +96,9 @@ for NAMESPACE in ${NAMESPACES[*]}; do
     DEPLOYMENTS=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[].metadata.name')
     # Itterate through each deployment
     for DEPLOYMENT in ${DEPLOYMENTS[*]}; do
-        TYPE=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.lastTransitionTime) | .status.conditions[-1].type' )
-        STATUS=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.lastTransitionTime) | .status.conditions[-1].status' )
-        REASON=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.lastTransitionTime) | .status.conditions[-1].message' )
+        TYPE=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.type) | .status.conditions[0].type' )
+        STATUS=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.type) | .status.conditions[0].status' )
+        REASON=$(echo "$DEPLOYMENTS_STATUS" | jq -r '.items[] | select(.metadata.name=="'$DEPLOYMENT'") | .status.conditions |= sort_by(.type) | .status.conditions[0].message' )
         # uncomment the following line to test a failure:
         # if [[ "$DEPLOYMENT" == "kubernetes-dashboard" ]]; then TYPE="Available"; STATUS="False"; fi
         case "${TYPE}-${STATUS}" in


### PR DESCRIPTION
This fixes #23.

According to #23 this seems to have changed with Kubernetes 1.20, however I've just recently encountered this.

I have a single deployment in my cluster with an Available condition that is older in time than it's Progressing condition. Then `check_kube_deployments.sh` will always look at the Progressing condition and will always tell that it has an Unknown status even if it's just fine.

So this commit changes the sorting of the conditions to sort by `.type` instead of `.lastTransitionTime`, then it picks the first element (which hopefully is the one with the type `Available`), it also picks up the status from the same sorting and status. Then it checks if it matches `Available-True` or `Available-False` or is `Unknown` just as before.